### PR TITLE
Install python-keystoneclient >=1.6.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 python-novaclient
-python-keystoneclient
+python-keystoneclient>=1.6.0
 python-neutronclient
 python-cinderclient
 pyYAML


### PR DESCRIPTION
This is required for overcast.

    + overcast deploy --cfg .overcast.yaml --cleanup cleanup-testjenkins-puppet-rjil-gate-undercloud-4 --suffix testjenkins-puppet-rjil-gate-undercloud-4 --mappings=environment/jio.map.ini --key /var/lib/jenkins/.ssh/id_rsa.pub undercloud
    Traceback (most recent call last):
      File "/var/lib/jenkins/workspace/puppet-rjil-gate-undercloud/venv/bin/overcast", line 5, in <module>
        from pkg_resources import load_entry_point
      File "/var/lib/jenkins/workspace/puppet-rjil-gate-undercloud/venv/local/lib/python2.7/site-packages/pkg_resources.py", line 3011, in <module>
        parse_requirements(__requires__), Environment()
      File "/var/lib/jenkins/workspace/puppet-rjil-gate-undercloud/venv/local/lib/python2.7/site-packages/pkg_resources.py", line 630, in resolve
        raise VersionConflict(dist,req) # XXX put more info here
    pkg_resources.VersionConflict: (python-keystoneclient 1.4.0 (/var/lib/jenkins/workspace/puppet-rjil-gate-undercloud/venv/lib/python2.7/site-packages), Requirement.parse('python-keystoneclient>=1.6.0'))
    Build step 'Execute shell' marked build as failure
    Finished: FAILURE