### PR TITLE
Support selecting from boot from volume and image

### DIFF
--- a/overcast/runner/__init__.py
+++ b/overcast/runner/__init__.py
@@ -161,8 +161,8 @@ class Node(object):
         # boot_volume
         ##
         try:
-            just_tmp_value=int(self.info['boot_volume'])
-        except:
+            int(self.info['boot_volume'])
+        except (ValueError, KeyError):
             self.info['boot_volume'] = None
 
     def poll(self, desired_status = 'ACTIVE'):


### PR DESCRIPTION
This patch allow one to select booting a node from volume and image by changing
"boot_volume" to a name which is mapped in the map file under volumes section.

Also changed nova boot from using block_device_mapping after cinder volume creation
to block_device_mapping_v2, which will do both creating volume and boot from the
volume. So overcast do not need to manage the volume separately, but nova will
handle creating/deleting volume along with the node.