### PR TITLE
Terminate replacements correctly

### DIFF
--- a/aasemble/deployment/cloud/aws.py
+++ b/aasemble/deployment/cloud/aws.py
@@ -3,8 +3,8 @@ import logging
 from libcloud.common.exceptions import BaseHTTPError
 from libcloud.compute.types import Provider
 
-from aasemble.deployment.cloud.base import CloudDriver
 import aasemble.deployment.cloud.models as cloud_models
+from aasemble.deployment.cloud.base import CloudDriver
 
 LOG = logging.getLogger(__name__)
 

--- a/aasemble/deployment/cloud/digitalocean.py
+++ b/aasemble/deployment/cloud/digitalocean.py
@@ -3,8 +3,8 @@ import logging
 from libcloud.compute.types import Provider
 from libcloud.utils.publickey import get_pubkey_openssh_fingerprint
 
-from aasemble.deployment.cloud.base import CloudDriver
 import aasemble.deployment.cloud.models as cloud_models
+from aasemble.deployment.cloud.base import CloudDriver
 
 LOG = logging.getLogger(__name__)
 

--- a/aasemble/deployment/cloud/gce.py
+++ b/aasemble/deployment/cloud/gce.py
@@ -4,8 +4,8 @@ import logging
 from libcloud.common.google import ResourceExistsError
 from libcloud.compute.types import Provider
 
-from aasemble.deployment.cloud.base import CloudDriver
 import aasemble.deployment.cloud.models as cloud_models
+from aasemble.deployment.cloud.base import CloudDriver
 
 LOG = logging.getLogger(__name__)
 

--- a/aasemble/deployment/tests/test_utils.py
+++ b/aasemble/deployment/tests/test_utils.py
@@ -78,7 +78,9 @@ class UtilsTests(unittest.TestCase):
         self.assertEquals(utils.interpolate('Hello, ${who:-someone}!', {}), 'Hello, someone!')
 
     def test_interpolate_replaces_variable_with_a_default_with_that_replacement(self):
-        self.assertEquals(utils.interpolate('Hello, ${who:-someone}!', {'who': 'world'}), 'Hello, world!')
+        self.assertEquals(utils.interpolate('Hello, ${who:-someone}! How are ${pronoun}?',
+                                            {'who': 'world', 'pronoun': 'you'}),
+                          'Hello, world! How are you?')
 
     def test_interpolate_returns_None_when_s_is_None(self):
         self.assertEqual(utils.interpolate(None, {'who': 'world'}), None)

--- a/aasemble/deployment/utils.py
+++ b/aasemble/deployment/utils.py
@@ -55,7 +55,8 @@ def parse_time(time_string):
 
 
 class TemplateWithDefaults(string.Template):
-    idpattern = '[_a-z][_a-z0-9]*(:-.*)?'
+    idpattern = '[_a-z][_a-z0-9]*(:-[^}]*)?'
+
 
 
 class defaultdict(dict):

--- a/aasemble/deployment/utils.py
+++ b/aasemble/deployment/utils.py
@@ -58,7 +58,6 @@ class TemplateWithDefaults(string.Template):
     idpattern = '[_a-z][_a-z0-9]*(:-[^}]*)?'
 
 
-
 class defaultdict(dict):
     def __init__(self, default=None, *args):
         self.default = default


### PR DESCRIPTION
When multiple replacements are present in the same string, avoid seeing them as one.

Fixes #40